### PR TITLE
chore: flask version bump

### DIFF
--- a/function/requirements.txt
+++ b/function/requirements.txt
@@ -1,5 +1,5 @@
 -i https://pypi.org/simple
-flask==3.1.0
+flask==3.1.1
 prometheus-flask-exporter==0.23.2
 werkzeug>=3.0.6 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
## What?
Update Flask dependency from version 3.1.0 to 3.1.1 in the `/function` directory.

## Why?
Flask 3.1.1 includes important bug fixes and security improvements:
- Fixed signing key selection order when key rotation is enabled via `SECRET_KEY_FALLBACKS` (security improvement - GHSA-4grg-w6v8-c28g)
- Fixed type hint for `cli_runner.invoke`
- Improved `flask --help` functionality
- Updated sans-io base class to handle views that return `AsyncIterable`

## How?
Modified `function/requirements.txt` to update the Flask version constraint.

## Files Changed
- function/requirements.txt

Resolves #304