### PR TITLE
chore: update piplock dependencies to latest versions

### DIFF
--- a/function/Pipfile.lock
+++ b/function/Pipfile.lock
@@ -26,11 +26,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:6b303f0b2aa85f1cb4e5303078fadcbcd4e476f114fab9b5007005711839325c",
-                "sha256:f5452aeddd9988eefa20f90f05ab66f17fce1ee2a36907fd30b05bbb5953814d"
+                "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202",
+                "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==8.2.0"
+            "version": "==8.2.1"
         },
         "flask": {
             "hashes": [
@@ -126,11 +126,11 @@
         },
         "prometheus-client": {
             "hashes": [
-                "sha256:252505a722ac04b0456be05c05f75f45d760c2911ffc45f2a06bcaed9f3ae3fb",
-                "sha256:594b45c410d6f4f8888940fe80b5cc2521b305a1fafe1c58609ef715a001f301"
+                "sha256:190f1331e783cf21eb60bca559354e0a4d4378facecf78f5428c39b675d20d28",
+                "sha256:cca895342e308174341b2cbf99a56bef291fbc0ef7b9e5412a0f26d653ba7094"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==0.21.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==0.22.1"
         },
         "prometheus-flask-exporter": {
             "hashes": [


### PR DESCRIPTION
## Description
Update Python package dependencies in Pipfile.lock to their latest versions for security and performance improvements.

## Changes Made
- Updated `click` from 8.2.0 to 8.2.1
- Updated `prometheus-client` from 0.21.1 to 0.22.1
  - Note: minimum Python version requirement changed from 3.8 to 3.9

## Benefits
- Security fixes and bug improvements in updated packages
- Better performance and compatibility
- Stay current with latest stable versions
- Reduced security vulnerabilities

## Testing
- [x] All existing tests pass
- [x] No breaking changes introduced
- [x] Dependencies are compatible with current Python version

## Related Issue
Resolves #314