### PR TITLE
chore: update Tika version from 3.2.1 to 3.2.3

### DIFF
--- a/function/Dockerfile.server
+++ b/function/Dockerfile.server
@@ -1,10 +1,10 @@
-FROM docker.io/apache/tika:3.2.1.0-full
+FROM docker.io/apache/tika:3.2.3.0-full
 
 ARG PORT=''
 ARG PORT_METRICS=''
 ARG POD_IP=''
 
-ENV TIKA_VERSION=3.2.1
+ENV TIKA_VERSION=3.2.3
 ENV CLASSPATH="/tika-server-standard-${TIKA_VERSION}.jar:/tika-extras/*:/opt/tika/libs/*"
 ENV PORT=${PORT:-8070}
 ENV PORT_METRICS=${PORT_METRICS:-7072}


### PR DESCRIPTION
This pull request updates the Tika server version used in the `function/Dockerfile.server` file. The change ensures that the Docker image and environment variable both reference the latest patch release of Apache Tika.

Dependency version update:

* Upgraded the base Docker image from `apache/tika:3.2.1.0-full` to `apache/tika:3.2.3.0-full` and updated the `TIKA_VERSION` environment variable from `3.2.1` to `3.2.3` to match the new image version.